### PR TITLE
Allows default values to be provided with getters

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,3 +1,4 @@
 Stephen Weinberg <stephen@q5comm.com>
 Andreas Krennmair https://github.com/akrennmair
 Daniel YC Lin <dlin.tw gmail>
+Ken Walters https://github.com/lostghost

--- a/README.rst
+++ b/README.rst
@@ -72,4 +72,28 @@ Code::
   c.GetBool("service-1", "compression") // returns true
   c.GetBool("service-2", "compression") // returns GetError
 
+Example 3
+---------
+
+Config::
+
+  [default]
+  host = something.com
+  port = 443
+  active = true
+  compression = off
+
+  [service-1]
+  compression = on
+
+  [service-2]
+  port = 444
+
+Code::
+
+  c, err := goconf.ReadConfigFile("something.config")
+  c.GetBoolDefault("default", "compression", true) // returns false
+  c.GetBoolDefault("service-1", "compression", true) // returns true
+  c.GetBoolDefault("service-2", "compression", true) // returns true
+
 .. vi:set et sw=2 ts=2:

--- a/get.go
+++ b/get.go
@@ -178,3 +178,27 @@ func (c *ConfigFile) GetBool(section string, option string) (value bool, err err
 
 	return value, nil
 }
+
+func (c *ConfigFile) GetStringDefault(section string, option string, defaultValue string) string {
+	value, err := c.GetString(section, option)
+	if err != nil {
+		return defaultValue
+	}
+	return value
+}
+
+func (c *ConfigFile) GetIntDefault(section string, option string, defaultValue int) int {
+	value, err := c.GetInt(section, option)
+	if err != nil {
+		return defaultValue
+	}
+	return value
+}
+
+func (c *ConfigFile) GetBoolDefault(section string, option string, defaultValue bool) bool {
+	value, err := c.GetBool(section, option)
+	if err != nil {
+		return defaultValue
+	}
+	return value
+}

--- a/goconf_test.go
+++ b/goconf_test.go
@@ -1,8 +1,10 @@
-package goconf
+package goconf_test
 
 import (
 	"strconv"
 	"testing"
+
+	. "github.com/shopsmart/goconf"
 )
 
 const confFile = `

--- a/goconf_test.go
+++ b/goconf_test.go
@@ -82,3 +82,25 @@ func TestBuild(t *testing.T) {
 		}
 	}
 }
+
+func TestDefaults(t *testing.T) {
+	c, err := ReadConfigBytes([]byte(confFile))
+	if err != nil {
+		t.Error(err)
+	}
+
+	s := c.GetStringDefault("", "nothere", "foo")
+	if s != "foo" {
+		t.Error("c.GetStringDefault(\"\", \"nothere\", \"foo\") returned incorrect answer")
+	}
+
+	i := c.GetIntDefault("", "nothere", 1)
+	if i != 1 {
+		t.Error("c.GetIntDefault(\"\", \"nothere\", 1) returned incorrect answer")
+	}
+
+	b := c.GetBoolDefault("", "nothere", true)
+	if b != true {
+		t.Error("c.GetBoolDefault(\"\", \"nothere\", true) returned incorrect answer")
+	}
+}

--- a/goconf_test.go
+++ b/goconf_test.go
@@ -4,7 +4,7 @@ import (
 	"strconv"
 	"testing"
 
-	. "github.com/shopsmart/goconf"
+	. "github.com/dlintw/goconf"
 )
 
 const confFile = `


### PR DESCRIPTION
We would like to pull defaults directly from the function call to avoid errors.  This feature adds three additional functions that allow a default value to be provided and, in turn, an error will not be provided (as it will default).  Note that this will override the default value within the defaults section if used.

We have also set the test file to be part of the test package so it does not appear with the library's main functionality.

Usage:
```go
c.GetStringDefault("section", "variable_one", "default_value")
c.GetBoolDefault("section", "variable_two", true)
c.GetIntDefault("section", "variable_three", -1)
```